### PR TITLE
Create README.md for the outbound oss training course extension

### DIFF
--- a/Contribution-and-Creation/Module-00.md
+++ b/Contribution-and-Creation/Module-00.md
@@ -1,0 +1,82 @@
+# Introduction
+
+- Maturity Levels
+- How companies manage open source
+- Motivation for open source contribution
+
+## 0.1 Maturity levels
+
+Corporate adoption of open source software can typically be classified with a model of maturity levels. These levels describe how open source software is used in an increasingly effective fashion to drive value and address business needs. One of the distinguishing factors for the different maturity levels is how outbound open source is handled in an organization. The insight that influencing the open source ecosystem is mainly done by participation in and contributing to open source projects is seen as a critical factor.
+
+A typical maturity model of corporate open source adoption looks like this (see for example [Haddad: Open Source Program Offices](https://www.linkedin.com/pulse/open-source-program-offices-primer-organizational-roles-haddad)):
+
+0. Denial - No or unconscious use of open source
+1. Consumption - Passive use of open source software
+2. Participation - Engagement with open source communities
+3. Contribution - Pragmatic contributions to open source projects
+4. Leadership - Strategic involvement with open source to drive business value
+
+To advance from one level to another, certain initiatives and structural and organizational elements are required.
+
+Going from consumption to participation, for example, will start with informal engagement and low-effort activities such as reporting bugs in upstream projects, which typically is driven by technical needs. On that level, decisions about open source contributions will normally be ad-hoc and be taken for individual cases only.
+
+Establishing dedicated decision making processes and formalizing contribution policies will lead to the next level. A typical step on this level is to establish an Open Source Program Office to support open source engagement and maintain an open source strategy and processes.
+
+On the leadership level, contribution processes are mature and scale. Corresponding tool chains are implemented. Own projects with the goal to create new open source communities are started if that's required and appropriate. This will typically come with leveraging open source foundations to enable cross-company collaboration to strategically use open source to accelerate creating business value.
+
+A company may decide to not progress to levels which are based on more contributions, and it's of course possible to build mature processes to consume open source software without contributing. In most cases, there will be some pressure to contribute back, though. This can arise from practical technical needs (missing functionalities or required bug fixes are typical reasons for contributing to open source projects), from the expectation to take responsibility in the open source ecosystem, or from the desire to reap the full benefits of the open source model.
+
+## 0.2 How companies manage open source: Open Source Program Offices
+
+An increasing number of organizations realized the tasks of managing open source in an enterprise, and the complex relationships that are inherent to the open source ecosystem when they are advancing in their engagement in open source, required dedicated support. For this reason, many of them started Open Source Program Offices (OSPOs) - though perhaps under a different name, such as Open Source Technology Centers, Open Source Community Development Team etc. OSPOs are a designated place where open source is supported, nurtured, shared, explained, and grown inside an organization. With such an office in place, businesses can establish and execute on their open source strategies with clear terms and responsibilities, giving their leaders, developers, marketers, and other staff the processes and tools they need to make open source a success within their operations.
+
+The TODO Group offers a [set of guides](https://todogroup.org/guides/) on how to get started with an OSPO. Companies that are new to this topic, might want to first take a look at [**How to create an open source program**](https://todogroup.org/guides/create-program/)
+
+## 0.3 Motivation for Open Source Contribution
+
+There is a broad spectrum of motivations for contributing to open source projects or starting new projects. Here, we can only list some examples.
+
+### Build software faster and better
+
+Consuming open source software typically increases the development speed and decreases development costs since one builds upon existing code and a working and tested functionality. One risk however is that required features or bug fixes are not provided by the community as quickly as needed. To mitigate that risk, it might make sense to build up the required skills and create these bug fixes and/or features yourself. Contributing them back to the upstream projects has important benefits:
+
+* Integrating "own" features into upstream projects makes maintenance a lot easier
+* Upstream versions can be directly used in own products and services
+* More features are obtained in shorter period of time
+* Higher quality is achieved in shorter period of time
+* Support available from core experts
+
+### Exercise strategic influence
+
+In addition to the benefits of open source software wrt. development velocity and quality mentioned above, contributing to open source projects can also be important from a strategic point of view. In the open source world, reputation and the ability to influence is typically build up by engaging in the community and by contributing. Thus, contributions to open source projects can help to:
+
+* Influence the direction of upstream open source projects
+* Gain (co)copyright on open source software packages
+* Access to the creativity of everyone interested in software
+
+Companies sometimes have the tendency to use money to exert influence. With open source projects this is not the most effective method. The currency of influence is contributions, because open source projects are usually much more driven by the work of individuals than the decisions of committees. So contributions work much more directly and effectively than being a member in an organization or paying for support or other services.
+
+Open source communities (particularly those run by the big open source foundations) provide a neutral place for collaboration between companies and other organizations. Thus, an open source approach could offer new ways of collaboration with suppliers, customers, partner and even competitors, just to mention industry- or domain-specific projects such as [Linux Foundation Energy](https://www.lfenergy.org/) or [Eclipse Tractus-X](https://projects.eclipse.org/proposals/eclipse-tractus-x). Establishing open source communities can also be a powerful means to create and maintain ecosystems and to establish de facto standards.
+
+### Attract, grow and retain talents
+
+Software (and therefore also open source software) becomes more and more ubiquitous in many products and areas. Thus, for many companies it is crucial to have a skilled and motivated software development workforce. This is not only true for software or cloud companies, but also for companies from other segments, such as traditional hardware producers who integrate software into their products more and more, or any other company which is becoming more dependent on software due to accelerating digital transformation. An open source strategy including open source contributions and community engagements supports this:
+
+* Increase developer satisfaction
+* Improve quality and boosts developer skills by peer review of each contribution by core experts
+* Make company visible as an attractive employer
+* Improve company's reputation, and with it the standing of developers in their communities
+
+### Be resilient and keep open source sustainable
+
+Open source software development is living from its communities. As mentioned above, the usage (also called consumption) of open source software helps to decrease costs and speed up development, but that's only possible because there is a community behind these projects maintaining the software. 
+To keep the open source development model sustainable, each consumer of open source software has therefore the responsibility to think about ways how to support these projects. These are some ways of engagement and support:
+
+* Contributions in terms of code, documentation, time, security reviews, testing
+* Donating infrastructure resources, e.g. compute resources for CI/CD and testing
+* Dedicating a "DevRel" person to the project
+* "Marketing support", for instance by featuring a project in company blogs etc.
+* Monetary support (some important projects are maintained by developers who do this in their spare time and thus can only invest limited time in the project)
+* Hosting hackathons and local community meet-ups
+
+It is important to understand that though open source software has no license costs when consuming it, it is not available for free. To keep these projects attractive for its consumers, steady engagement and support is required. That's why it is important to have a strategy for open source contributions in place.

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -21,7 +21,6 @@ This program is designed around three main thematic areas, which will be formatt
 * Motivation for contribution
   * Diving Deep into starting your organization's journey in contributing to open source projects
   * Exploring various contribution models and procedures suitable for enterprises of all scales
-  * Managing and encouraging spare-time contributions
     
 **MODULE 2 - CREATION**
 

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -18,6 +18,7 @@ This program is designed around three main thematic areas, which will be formatt
 **MODULE 1 - COLLABORATION**
 
 * Transitioning from usage (also called consumption) to Contribution
+* Motivation for contribution
   * Diving Deep into starting your organization's journey in contributing to open source projects
   * Exploring various contribution models and procedures suitable for enterprises of all scales
   * Managing and encouraging spare-time contributions

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -33,7 +33,6 @@ This program is designed around three main thematic areas, which will be formatt
 **MODULE 3 - SUSTAINABILITY AND RESILIENCE**
 
 * Growing and nurturing and keeping an open source project resilient
-   * Techniques and best practices for promoting the open source project that matters to your organization
    * Building and managing vibrant communities around the open soruce projects that matter to your organization.
    * An introduction to open source software analytics and crucial open source metrics to gauge success and areas of improvement
 

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -39,17 +39,22 @@ By the end of this training course, participants will be well-equipped with the 
 
 ### Prerequisite Knowledge:
 
-* Basic Understanding of Software Development: Familiarity with software development processes and terminology.
-* Awareness of Open Source Concepts: A general understanding of what open source is.
+* Familiarity with Open Source Software Development: Understanding of open source software development processes and terminology.
+* Awareness of Open Source Concepts: A general knowledge of open source in terms of legal, community, business, and ethical aspects.
+* Experience in Managing Open Source in Organizations: For example, familiarity with the operations of an Open Source Program Office (OSPO).
+* Preparatory Reading:
+  * [Starting an Open Source Project](thttps://todogroup.org/guides/starting/): A guide to initiating an open source project.
+  * [Building an Inclusive Community](https://todogroup.org/guides/diversity-inclusion/): A guide focused on fostering diversity and inclusion in open source communities.
+  * Read the guide Building Leadership (https://todogroup.org/guides/building-leadership/): A guide on developing leadership within open source projects.
 
 ### What I Will Learn In The Open Source Contribution and Creation Course
 
 By the end of this course, participants will be equipped with the knowledge and skills to:
 
-* Manage outbound open source projects within organization entities effectively 
-* Understand legal and ethical implications
-* Motivations, and best practices to move from usage to contribution
-* Integrate open source strategies within their organizations.
+* Manage outbound open source projects within an organization effectively 
+* Understand legal and ethical implications when managing open source in an organization
+* Motivations, and best practices to move from usage to contribution in organizations
+* Integrate open source strategies within an organization.
 
 Upon successful completion, participants will receive a certificate, demonstrating their proficiency in managing outbound open source initiatives within organizations.
 

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -33,7 +33,6 @@ This program is designed around three main thematic areas, which will be formatt
 **MODULE 3 - SUSTAINABILITY AND RESILIENCE**
 
 * Growing and nurturing and keeping an open source project resilient
-   * Building and managing vibrant communities around the open soruce projects that matter to your organization.
    * An introduction to open source software analytics and crucial open source metrics to gauge success and areas of improvement
 
 By the end of this training course, participants will be well-equipped with the knowledge and tools necessary to contribute to open source projects and kickstart and release open source projects, ensuring they align with their organization's strategic objectives and foster a culture of collaboration and innovation.

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -11,7 +11,7 @@ This course series is an extension of modules 6 and 7 from the OSPO 101 training
 ### Program Overview
 
 For people at organizations looking to enhance their open source and/or IT strategy (people shaping the process), delving into outbound open source – which involves contributing to existing projects or initiating new ones – can be a transformative experience. 
-This training course is designed to guide open source managers adn stakeholders within organizations through this journey.
+This training course is designed to guide open source managers and stakeholders within organizations through this journey.
 
 This program is designed around three main thematic areas, which will be formatted into modules:
 

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -29,13 +29,29 @@ This program is designed around three main thematic areas, which will be formatt
   * Understanding the strategic advantages of launching open source initiatives for your organization.
   * Navigating through legal intricacies, including Intellectual Property (IP) and licensing considerations.
   * Mastering administrative and technical aspects, from repository management to selecting the right tools for your project.
-  * 
+  
 **MODULE 3 - SUSTAINABILITY AND RESILIENCE**
 
 * Growing and nurturing and keeping an open source project resilient
    * An introduction to open source software analytics and crucial open source metrics to gauge success and areas of improvement
 
 By the end of this training course, participants will be well-equipped with the knowledge and tools necessary to contribute to open source projects and kickstart and release open source projects, ensuring they align with their organization's strategic objectives and foster a culture of collaboration and innovation.
+
+### Prerequisite Knowledge:
+
+* Basic Understanding of Software Development: Familiarity with software development processes and terminology.
+* Awareness of Open Source Concepts: A general understanding of what open source is.
+
+### What I Will Learn In The Open Source Contribution and Creation Course
+
+By the end of this course, participants will be equipped with the knowledge and skills to:
+
+* Manage outbound open source projects within organization entities effectively 
+* Understand legal and ethical implications
+* Motivations, and best practices to move from usage to contribution
+* Integrate open source strategies within their organizations.
+
+Upon successful completion, participants will receive a certificate, demonstrating their proficiency in managing outbound open source initiatives within organizations.
 
 ***
 

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -1,66 +1,119 @@
-# OSPO 101 Training Extension Module 6 & 7
-## Open Source Contribution and Creation
+# Contributing and Launching Open Source Projects within Organizations (LFC115)
 
-This course series is an extension of modules 6 and 7 from the OSPO 101 training course and is based on the [content from the outbound open source guide](https://github.com/todogroup/outbound-oss). Before taking this course, we encourage students to go through the introductory courses on using and creating open source projects:
+## Course Description 
 
-* [OSPO 101 - Module 6: Understanding Upstream Open Source Projects](https://github.com/todogroup/ospo-career-path/blob/main/OSPO-101/module6/README.md)
-* [OSPO 101 - Module 7: Open Source Creation](https://github.com/todogroup/ospo-career-path/tree/main/OSPO-101/module7)
+Contribute and Launch Open Source Projects is a 3-module course series for workers within organizations managing open source that builds on the accumulated wisdom of the previous [Guide to Outbound Open Source Software](https://todogroup.org/guides/outbound-oss/). This course offers management and strategic insights into why and how organizations can efficiently contribute to open source projects.
 
-***
+Upon completion, learners will be equipped to establish and manage open source projects more effectively. They will gain a clear understanding of how to tailor these practices to their specific organizational context and teams, whether in a large or small organization.
 
-### Program Overview
+## Course Learning Outcomes
 
-For people at organizations looking to enhance their open source and/or IT strategy (people shaping the process), delving into outbound open source – which involves contributing to existing projects or initiating new ones – can be a transformative experience. 
-This training course is designed to guide open source managers and stakeholders within organizations through this journey.
+By the end of this course, you should be able to:
 
-This program is designed around three main thematic areas, which will be formatted into modules:
+* Understand and Communicate the Strategic Importance of Open Source Contribution: You will gain an in-depth understanding of why contributing to open source projects is strategically beneficial for organizations
+* Develop Project Management Skills in Open Source Context: You will be equipped with skills to effectively establish and manage open source projects in an organization context.
+* Enhance Team Collaboration in Open Source Projects: Participants will learn techniques to improve collaboration and coordination across teams/departments
+* Contribute and Launch Open Source Projects is a 3-module course series for workers within organizations managing open source that builds on the accumulated wisdom of the previous [Guide to Outbound Open Source Software](https://todogroup.org/guides/outbound-oss/).
 
-**MODULE 1 - COLLABORATION**
+## Course Audience
 
-* Transitioning from usage (also called consumption) to Contribution
-* Motivation for contribution
-  * Diving Deep into starting your organization's journey in contributing to open source projects
-  * Exploring various contribution models and procedures suitable for enterprises of all scales
-    
-**MODULE 2 - CREATION**
+This course series is designed to help executives and managers shaping the processes of open source within organizations to understand and articulate the basic concepts for contributing and launching open source projects within their organization.
 
-* Embarking on the organization's open source project releases
-  * An in-depth look at the  lifecycle of open source projects.
-  * Understanding the strategic advantages of launching open source initiatives for your organization.
-  * Navigating through legal intricacies, including Intellectual Property (IP) and licensing considerations.
-  * Mastering administrative and technical aspects, from repository management to selecting the right tools for your project.
+## Knowledge/Skills Prerequisites
+
+Before enrolling, students should have a basic understanding of software development and business concepts. We recommend students take the following courses in advance:
+
+* LFD102 - A Beginner’s Guide to Open Source Software Development
+* LFC202-207 - Open Source Management & Strategy
+* LFC193  - Introduction to Open Source License Compliance Management
+* LFC105 - Antitrust Laws and Open Source Software Project Management and Participation
+
+**Additional Industry-Vertical Courses**
+
+* LFD137 - Open Source Contribution in Finance: This course is recommended for students in the finance sector who are enrolled in the 'Contributing and Launching Open Source Projects within Organizations' Course
   
-**MODULE 3 - SUSTAINABILITY AND RESILIENCE**
+## Lab/System Prerequisites
 
-* Growing and nurturing and keeping an open source project resilient
-   * An introduction to open source software analytics and crucial open source metrics to gauge success and areas of improvement
+None
 
-By the end of this training course, participants will be well-equipped with the knowledge and tools necessary to contribute to open source projects and kickstart and release open source projects, ensuring they align with their organization's strategic objectives and foster a culture of collaboration and innovation.
+## What the Course Prepares For
 
-### Prerequisite Knowledge:
+This course prepares students working in organizations for advanced roles in IT management, focusing on the strategic and efficient contribution to open source projects. Learners are equipped with the skills necessary for roles such as Open Source Project Manager or Open Source Program Office Lead.
 
-* Familiarity with Open Source Software Development: Understanding of open source software development processes and terminology.
-* Awareness of Open Source Concepts: A general knowledge of open source in terms of legal, community, business, and ethical aspects.
-* Experience in Managing Open Source in Organizations: For example, familiarity with the operations of an Open Source Program Office (OSPO).
-* Preparatory Reading:
-  * [Starting an Open Source Project](thttps://todogroup.org/guides/starting/): A guide to initiating an open source project.
-  * [Building an Inclusive Community](https://todogroup.org/guides/diversity-inclusion/): A guide focused on fostering diversity and inclusion in open source communities.
-  * Read the guide Building Leadership (https://todogroup.org/guides/building-leadership/): A guide on developing leadership within open source projects.
+## Outline
+Chapter titles and learning objectives for each chapter
 
-### What I Will Learn In The Open Source Contribution and Creation Course
+* Introduction
+  * Understand the maturity levels in open source projects.
+  * Explore the motivations for contributing to open source, including:
+       * Building software faster and better.
+       * Exercising strategic influence.
+       * Attracting, growing, and retaining talent.
+       * Sustaining the open source ecosystem.
+* How to Contribute to OSS Projects
+  * Define your organization's open source goals and strategy.
+  * Establish guiding principles and processes for open source contribution, including:
+       * Understanding the guiding principles.
+       * Identifying who holds decision-making responsibilities.
+       * Outlining the general structure and scope of the contribution process.
+       * Process for obtaining company approval for contributions.
+  * Learn about various open source contribution models.
+* Starting Open Source Projects
+  * Analyze the motivation behind starting open source projects.
+  * Understand the project life cycle, including:
+     * Planning or Concept Phase.
+     * Active or Development Phase.
+     * Mature or Maintenance Phase.
+     * Obsolete or End of Life Phase.
+  * Delve into legal and governance considerations:
+     * Choosing the right license.
+     * Understanding the Contributor License Agreement (CLA) and Developer Certificate of Origin (DCO).
+     * Establishing project governance.
+     * Differentiating between various project levels.
+  * Master community management, including creating a Code of Conduct.
+* Technical Considerations, Tooling, and Best Practices
+  * Learn about user management in open source projects.
+  * Set up and maintain a repository.
+  * Provide appropriate license and copyright information.
+  * Manage CLA/DCO effectively.
+  * Implement credential scanning.
+  * Understand quality criteria and the CII Best Practices Badge Program.
+  * Learn about repository linting.
+* Building an Open Source Metrics Strategy
+  * Develop strategies for measuring and evaluating the success and impact of open source releases.
 
-By the end of this course, participants will be equipped with the knowledge and skills to:
+## Course Length 
 
-* Manage outbound open source projects within an organization effectively 
-* Understand legal and ethical implications when managing open source in an organization
-* Motivations, and best practices to move from usage to contribution in organizations
-* Integrate open source strategies within an organization.
+1. Introduction:
+* Estimated lecture time: 1 hour
+* Touchpoint exam: 10 minutes
+2. How to Contribute to OSS Projects:
+* Estimated lecture time: 3 hours
+* Touchpoint exam: 10 minutes
+3. Starting Open Source Projects:
+* Estimated lecture time:  3 hours
+* Touchpoint exam: 10 minutes
+4. Technical Considerations, Tooling, and Best Practices:
+* Estimated lecture time: 2 hours
+* Touchpoint exam: 10 minutes
+5. Building an Open Source Metrics Strategy:
+* Estimated lecture time: 1 hour
+* Touchpoint exam: 10 minutes
 
-Upon successful completion, participants will receive a certificate, demonstrating their proficiency in managing outbound open source initiatives within organizations.
+6. Final Exam
+* Estimated time: 15 minutes
 
-***
+TOTAL LECTURE TIME: 10 Hours
+TOTAL EXAM TIME: 1 Hour
 
-### Audience
 
-This course series is designed to help those open source stakeholders shaping the process regarding open source integration across the organization's work units and providing IT strategic advice, understand and articulate the basic concepts for building effective open source practices within their organization. It is also helpful for a leadership audience responsible for setting up effective
-program management of open source in their organization. Before enrolling, students should have a basic understanding of software development and business concepts
+## Course Author Bio and Picture
+
+TBD
+
+
+## Digital Badge Description, Skills and Tags
+
+Earners of the Contributing and Launching Open Source Projects within Organizations (LFC115*) course badge have demonstrated a comprehensive understanding of managing open source projects within an organization context. They've gained skills in effectively setting up strategies and managing team contributions to open source projects and launching open source projects. The holder of this badge has demonstrated skills in project lifecycle management, legal and governance considerations, community management, and the establishment of effective open source metrics strategies.
+
+`open source management and strategy`; `open source governance`; `project management`; `open source project life cycle`

--- a/Contribution-and-Creation/README.md
+++ b/Contribution-and-Creation/README.md
@@ -1,0 +1,47 @@
+# OSPO 101 Training Extension Module 6 & 7
+## Open Source Contribution and Creation
+
+This course series is an extension of modules 6 and 7 from the OSPO 101 training course and is based on the [content from the outbound open source guide](https://github.com/todogroup/outbound-oss). Before taking this course, we encourage students to go through the introductory courses on using and creating open source projects:
+
+* [OSPO 101 - Module 6: Understanding Upstream Open Source Projects](https://github.com/todogroup/ospo-career-path/blob/main/OSPO-101/module6/README.md)
+* [OSPO 101 - Module 7: Open Source Creation](https://github.com/todogroup/ospo-career-path/tree/main/OSPO-101/module7)
+
+***
+
+### Program Overview
+
+For people at organizations looking to enhance their open source and/or IT strategy (people shaping the process), delving into outbound open source – which involves contributing to existing projects or initiating new ones – can be a transformative experience. 
+This training course is designed to guide open source managers adn stakeholders within organizations through this journey.
+
+This program is designed around three main thematic areas, which will be formatted into modules:
+
+**MODULE 1 - COLLABORATION**
+
+* Transitioning from usage (also called consumption) to Contribution
+  * Diving Deep into starting your organization's journey in contributing to open source projects
+  * Exploring various contribution models and procedures suitable for enterprises of all scales
+  * Managing and encouraging spare-time contributions
+    
+**MODULE 2 - CREATION**
+
+* Embarking on the organization's open source project releases
+  * An in-depth look at the  lifecycle of open source projects.
+  * Understanding the strategic advantages of launching open source initiatives for your organization.
+  * Navigating through legal intricacies, including Intellectual Property (IP) and licensing considerations.
+  * Mastering administrative and technical aspects, from repository management to selecting the right tools for your project.
+  * 
+**MODULE 3 - SUSTAINABILITY AND RESILIENCE**
+
+* Growing and nurturing and keeping an open source project resilient
+   * Techniques and best practices for promoting the open source project that matters to your organization
+   * Building and managing vibrant communities around the open soruce projects that matter to your organization.
+   * An introduction to open source software analytics and crucial open source metrics to gauge success and areas of improvement
+
+By the end of this training course, participants will be well-equipped with the knowledge and tools necessary to contribute to open source projects and kickstart and release open source projects, ensuring they align with their organization's strategic objectives and foster a culture of collaboration and innovation.
+
+***
+
+### Audience
+
+This course series is designed to help those open source stakeholders shaping the process regarding open source integration across the organization's work units and providing IT strategic advice, understand and articulate the basic concepts for building effective open source practices within their organization. It is also helpful for a leadership audience responsible for setting up effective
+program management of open source in their organization. Before enrolling, students should have a basic understanding of software development and business concepts


### PR DESCRIPTION
This commit adds the readme documentation that explains the program overview, modules, and audience for the OSPO 101 extension of modules 6 and 7, which also corresponds to the outbound oss guide content.